### PR TITLE
Set white color of group chat title

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -37,6 +37,20 @@
 - (id)canvasView;
 @end
 
+@interface CKDetailsCell : UITableViewCell
+@end
+
+
+@protocol CKDetailsCell <NSObject>
+@required
++ (NSString *)reuseIdentifier;
++ (BOOL)shouldHighlight;
+@end
+
+@interface CKDetailsGroupNameCell : CKDetailsCell <CKDetailsCell>
+-(UILabel*)textLabel;
+@end
+
 
 static CKUIThemeDark *darkTheme;
 
@@ -93,6 +107,15 @@ static CKUIThemeDark *darkTheme;
 	tv.textColor = UIColor.whiteColor;
 }
 %end
+
+%hook CKDetailsGroupNameCell
+-(UILabel*)textLabel {
+	UILabel* tl = %orig;
+	tl.textColor = [UIColor whiteColor];
+	return tl;
+}
+%end
+
 %end
 
 

--- a/Tweak.xm
+++ b/Tweak.xm
@@ -116,6 +116,14 @@ static CKUIThemeDark *darkTheme;
 }
 %end
 
+%hook CKDetailsContactsTableViewCell
+- (UILabel*)nameLabel {
+	UILabel* nl = %orig;
+	nl.textColor = [UIColor whiteColor];
+	return nl;
+}
+%end
+
 %end
 
 

--- a/control
+++ b/control
@@ -1,7 +1,7 @@
 Package: com.sticktron.darkmessages
 Name: DarkMessages (iOS 10)
 Depends: mobilesubstrate
-Version: 1.0.2
+Version: 1.0.3
 Architecture: iphoneos-arm
 Description: Native Dark Theme for Messages App!
 Maintainer: Sticktron

--- a/control
+++ b/control
@@ -1,7 +1,7 @@
 Package: com.sticktron.darkmessages
 Name: DarkMessages (iOS 10)
 Depends: mobilesubstrate
-Version: 1.0.3
+Version: 1.0.4
 Architecture: iphoneos-arm
 Description: Native Dark Theme for Messages App!
 Maintainer: Sticktron


### PR DESCRIPTION
I don't have a device with iOS 10 to test it, but it should work. Please, check before pulling.