### PR TITLE
Night Shift, optimization, color fixes and theme of contact view

### DIFF
--- a/DarkMessages.h
+++ b/DarkMessages.h
@@ -40,7 +40,7 @@
 
 @interface CKUIThemeDark : CKUITheme
 - (UIColor *)entryFieldButtonColor;
-- (UIColor *)entryFieldDarkStyleButtonColor;
+- (UIColor *)entryFieldGrayColor;
 - (id)blue_balloonColors;
 - (id)green_balloonColors;
 - (id)gray_balloonColors;

--- a/DarkMessages.h
+++ b/DarkMessages.h
@@ -46,14 +46,19 @@
 - (id)gray_balloonColors;
 @end
 
+@interface CNContactStyle : NSObject
+@property (nonatomic, retain) UIColor *backgroundColor;
+@property (nonatomic, retain) UIColor *headerBackgroundColor;
+@property (nonatomic, retain) UIColor *contactHeaderBackgroundColor;
++ (id)darkStyle;
+@end
+
 @interface NightModeControl : NSObject // from CoreBrightness
 - (void)enableBlueLightReduction:(BOOL)arg1 withOption:(int)arg2;
 @end
 
 @interface CBBlueLightClient : NSObject
 + (BOOL)supportsBlueLightReduction;
-- (BOOL)setEnabled:(BOOL)arg1;
-- (BOOL)setEnabled:(BOOL)arg1 withOption:(int)arg2;
 @end
 
 @interface AXBackBoardServer : NSObject

--- a/DarkMessages_CK.xm
+++ b/DarkMessages_CK.xm
@@ -200,6 +200,23 @@ static void handleQuitMessages(CFNotificationCenterRef center, void *observer, C
 %end
 
 
+// Contacts
+%hook CNContactStyle
+
++ (id)currentStyle {
+	return [%c(CNContactStyle) darkStyle];
+}
+
++ (id)darkStyle {
+	CNContactStyle *style = %orig;
+	style.backgroundColor = style.headerBackgroundColor;
+	style.contactHeaderBackgroundColor = style.headerBackgroundColor;
+	return style;
+}
+
+%end
+
+
 //------------------------------------------------------------------------------
 
 

--- a/DarkMessages_CK.xm
+++ b/DarkMessages_CK.xm
@@ -145,7 +145,7 @@ static void handleQuitMessages(CFNotificationCenterRef center, void *observer, C
 %hook CKMessageEntryView
 - (UILabel *)collpasedPlaceholderLabel {
 	UILabel *label = %orig;
-	label.textColor = [darkTheme entryFieldDarkStyleButtonColor];
+	label.textColor = [darkTheme entryFieldGrayColor];
 	return label;
 }
 %end

--- a/DarkMessages_CK.xm
+++ b/DarkMessages_CK.xm
@@ -90,115 +90,91 @@ static void handleQuitMessages(CFNotificationCenterRef center, void *observer, C
 
 %hook CKUIBehaviorPhone
 - (id)theme {
-	return isDark ? darkTheme : %orig;
+	return darkTheme;
 }
 %end
 
 %hook CKUIBehaviorPad
 - (id)theme {
-	return isDark ? darkTheme : %orig;
+	return darkTheme;
 }
 %end
 
 // fix navbar: style
 %hook CKAvatarNavigationBar
 - (void)_setBarStyle:(int)style {
-	if (isDark) {
-		%orig(1);
-	} else {
-		%orig;
-	}
+	%orig(1);
 }
 %end
 
 // fix navbar: contact names
 %hook CKAvatarContactNameCollectionReusableView
 - (void)setStyle:(int)style {
-	if (isDark) {
-		%orig(3);
-	} else {
-		%orig;
-	}
+	%orig(3);
 }
 %end
 
 // fix navbar: group names
 %hook CKAvatarTitleCollectionReusableView
 - (void)setStyle:(int)style {
-	if (isDark) {
-		%orig(3);
-	} else {
-		%orig;
-	}
+	%orig(3);
 }
 %end
 
 // fix navbar: new message label
 %hook CKNavigationBarCanvasView
 - (id)titleView {
-	if (isDark) {
-		id tv = %orig;
-		if (tv && [tv respondsToSelector:@selector(setTextColor:)]) {
-			[(UILabel *)tv setTextColor:UIColor.whiteColor];
-		}
-		return tv;
-	} else {
-		return %orig;
+	id tv = %orig;
+	if (tv && [tv respondsToSelector:@selector(setTextColor:)]) {
+		[(UILabel *)tv setTextColor:UIColor.whiteColor];
 	}
+	return tv;
 }
 %end
 
 // fix group details: contact names
 %hook CKDetailsContactsTableViewCell
 - (UILabel *)nameLabel {
-	if (isDark) {
-		UILabel *nl = %orig;
-		nl.textColor = UIColor.whiteColor;
-		return nl;
-	} else {
-		return %orig;
-	}
+	UILabel *nl = %orig;
+	nl.textColor = UIColor.whiteColor;
+	return nl;
 }
 %end
 
 // fix message entry inactive color
 %hook CKMessageEntryView
 - (UILabel *)collpasedPlaceholderLabel {
-	if (isDark) {
-		UILabel *label = %orig;
-		label.textColor = [darkTheme entryFieldDarkStyleButtonColor];
-		return label;
-	} else {
-		return %orig;
-	}
+	UILabel *label = %orig;
+	label.textColor = [darkTheme entryFieldDarkStyleButtonColor];
+	return label;
 }
 %end
 
 // change chat bubble colors
 %hook CKUIThemeDark
 - (id)blue_balloonColors {
-	if (isDark && blueBalloonColor && ![blueBalloonColor isEqualToString:@"default"]) {
+	if (blueBalloonColor && ![blueBalloonColor isEqualToString:@"default"]) {
 		return @[ [UIColor colorFromHexString:blueBalloonColor] ];
 	} else {
 		return %orig;
 	}
 }
 - (id)green_balloonColors {
-	if (isDark && greenBalloonColor && ![greenBalloonColor isEqualToString:@"default"]) {
+	if (greenBalloonColor && ![greenBalloonColor isEqualToString:@"default"]) {
 		return @[ [UIColor colorFromHexString:greenBalloonColor], [UIColor colorFromHexString:greenBalloonColor]];
 	} else {
 		return %orig;
 	}
 }
 - (id)gray_balloonColors {
-	if (isDark && grayBalloonColor && ![grayBalloonColor isEqualToString:@"default"]) {
+	if (grayBalloonColor && ![grayBalloonColor isEqualToString:@"default"]) {
 		return @[ [UIColor colorFromHexString:grayBalloonColor], [UIColor colorFromHexString:grayBalloonColor] ];
 	} else {
 		return %orig;
 	}
 }
 - (id)blue_balloonTextColor {
-	if (isDark && blueBalloonColor && ![blueBalloonColor isEqualToString:@"default"]) {
+	if (blueBalloonColor && ![blueBalloonColor isEqualToString:@"default"]) {
 		UIColor *balloonColor = [UIColor colorFromHexString:blueBalloonColor];
 		return ([balloonColor isLightColor]) ? UIColor.blackColor : UIColor.whiteColor;
 	} else {
@@ -206,7 +182,7 @@ static void handleQuitMessages(CFNotificationCenterRef center, void *observer, C
 	}
 }
 - (id)green_balloonTextColor {
-	if (isDark && greenBalloonColor && ![greenBalloonColor isEqualToString:@"default"]) {
+	if (greenBalloonColor && ![greenBalloonColor isEqualToString:@"default"]) {
 		UIColor *balloonColor = [UIColor colorFromHexString:greenBalloonColor];
 		return ([balloonColor isLightColor]) ? UIColor.blackColor : UIColor.whiteColor;
 	} else {
@@ -214,7 +190,7 @@ static void handleQuitMessages(CFNotificationCenterRef center, void *observer, C
 	}
 }
 - (id)gray_balloonTextColor {
-	if (isDark && grayBalloonColor && ![grayBalloonColor isEqualToString:@"default"]) {
+	if (grayBalloonColor && ![grayBalloonColor isEqualToString:@"default"]) {
 		UIColor *balloonColor = [UIColor colorFromHexString:grayBalloonColor];
 		return ([balloonColor isLightColor]) ? UIColor.blackColor : UIColor.whiteColor;
 	} else {
@@ -234,8 +210,11 @@ static void handleQuitMessages(CFNotificationCenterRef center, void *observer, C
 		
 		loadSettings();
 		
-		darkTheme = [[%c(CKUIThemeDark) alloc] init];
-		%init;
+		// only execute hooks if dark mode is active
+		if (isDark) {
+			darkTheme = [[%c(CKUIThemeDark) alloc] init];
+			%init;
+		}
 		
 		// listen for requests from SpringBoard to prompt user to restart Messages
 		CFNotificationCenterAddObserver(CFNotificationCenterGetDarwinNotifyCenter(),

--- a/DarkMessages_SB.xm
+++ b/DarkMessages_SB.xm
@@ -296,26 +296,13 @@ static void handleRelaunchMessagesApp(CFNotificationCenterRef center, void *obse
 %end
 
 // Night Shift detection
-%hook CBBlueLightClient
-- (BOOL)setEnabled:(BOOL)enabled {
-	BOOL result = %orig;
-	DebugLog(@"NightShift turned %@ (success=%d)", enabled?@"ON":@"OFF", result);
-	
-	if (nightShiftControlEnabled) {
-		setDarkMode(enabled);
-	}
-	
-	return result;
-}
-- (BOOL)setEnabled:(BOOL)enabled withOption:(int)option {
-	BOOL result = %orig;
-	DebugLog(@"NightShift turned %@ with option:%d (success=%d)", enabled?@"ON":@"OFF", option, result);
-	
-	if (nightShiftControlEnabled) {
-		setDarkMode(enabled);
-	}
-	
-	return result;
+%hook BrightnessSystemClientExportedObj
+- (void)notifyChangedProperty:(NSString *)key value:(NSDictionary *)dict {
+    %orig;
+    if (nightShiftControlEnabled &&
+    	[key isEqualToString:@"CBBlueReductionStatus"] && dict[@"BlueReductionEnabled"]) {
+            setDarkMode([dict[@"BlueReductionEnabled"] boolValue]);
+    }
 }
 %end
 


### PR DESCRIPTION
This pull request contains ~three~ four changes:

* Made the contact section dark.

* When working on my project that also relies on Night Shift detection, I realized that the method used in DarkMessenger only works with manually toggling.

* The message field's text color is black when not active.

* Only execute hooks when dark mode is activated – simply put: only check the boolean flag once, not in every method.